### PR TITLE
Fixes error when right-clicking on LD editor

### DIFF
--- a/editors/Viewer.py
+++ b/editors/Viewer.py
@@ -744,6 +744,7 @@ class Viewer(EditorPanel, DebugViewer):
         self.Editor.Bind(wx.EVT_MOUSEWHEEL, self.OnMouseWheelWindow)
         self.Editor.Bind(wx.EVT_SIZE, self.OnMoveWindow)
         self.Editor.Bind(wx.EVT_MOUSE_EVENTS, self.OnViewerMouseEvent)
+        self.Editor.Bind(wx.EVT_MOUSE_CAPTURE_LOST, lambda evt: None)
 
     def SetCurrentCursor(self, cursor):
         if self.Mode != MODE_MOTION:


### PR DESCRIPTION
Right clicking on the LD editor causes a wx assertion error. It complains that the window that captured the mouse didn't process wx.EVT_MOUSE_CAPTURE_LOST.

This line fixes the problem, but could be a suppression of the symptoms rather than the cure of the disease. See: https://github.com/wxWidgets/wxWidgets/issues/17961