### PR TITLE
Fixup for Python 3.10 +.

### DIFF
--- a/opc_ua/opcua_client_maker.py
+++ b/opc_ua/opcua_client_maker.py
@@ -507,9 +507,9 @@ class OPCUAClientList(list):
             if len(self) == 0:
                 v["IEC"] = 0
             else:
-                iecnums = set(zip(*self)[lstcolnames.index("IEC")])
+                iecnums = set(list(zip(*self))[lstcolnames.index("IEC")])
                 greatest = max(iecnums)
-                holes = set(range(greatest)) - iecnums
+                holes = set(range(int(greatest))) - iecnums
                 v["IEC"] = min(holes) if holes else greatest+1
 
         if v["IdType"] not in UA_NODE_ID_types:


### PR DESCRIPTION
Discovered  following trace back for:
```
(osie-env) ivan@t580:~/nexedi/osie-env/Beremiz/beremiz$ python
Python 3.10.12 (main, Feb  4 2025, 14:57:36) [GCC 11.4.0] on linux
....
Traceback (most recent call last):
  File "/home/ivan/nexedi/osie-env/Beremiz/beremiz/opc_ua/opcua_client_maker.py", line 132, in OnDrop
    self.ParentWindow.OnNodeDnD()
  File "/home/ivan/nexedi/osie-env/Beremiz/beremiz/opc_ua/opcua_client_maker.py", line 212, in OnNodeDnD
    self.model.AddRow(value)
  File "/home/ivan/nexedi/osie-env/Beremiz/beremiz/opc_ua/opcua_client_maker.py", line 115, in AddRow
    if self.data.append(value):
  File "/home/ivan/nexedi/osie-env/Beremiz/beremiz/opc_ua/opcua_client_maker.py", line 510, in append
    iecnums = set(zip(*self)[lstcolnames.index("IEC")])
TypeError: 'zip' object is not subscriptable
```


